### PR TITLE
Remove "MessageTarget" import

### DIFF
--- a/chaintable.py
+++ b/chaintable.py
@@ -2,7 +2,7 @@ from textual.app import App, ComposeResult
 from textual.widgets import Button, Static, DataTable, Label, Tree, Input
 from textual.reactive import reactive
 from textual.containers import Container, Horizontal
-from textual.message import Message, MessageTarget
+from textual.message import Message
 
 from rule import Rule
 
@@ -71,15 +71,15 @@ class ChainTable(Static):
         table.focus()
 
     class SelectRule(Message):
-        def __init__(self, sender: MessageTarget, rule: Rule):
+        def __init__(self, rule: Rule):
             self.rule = rule
-            super().__init__(sender)
+            super().__init__()
 
     async def on_data_table_cell_selected(self, msg):
         rule: Rule = self.rows[msg.coordinate.row]
         if rule.action in rule.BUILTIN:
             return
-        await self.post_message(self.SelectRule(self, rule))
+        self.post_message(self.SelectRule(rule))
 
     async def on_data_table_cell_highlighted(self, msg):
         rule: Rule = self.rows[msg.coordinate.row]

--- a/iptablesboard.py
+++ b/iptablesboard.py
@@ -1,7 +1,7 @@
 from textual.widgets import Button, Static, DataTable, Label
 from textual.containers import Container, Horizontal
 from textual.scroll_view import ScrollView
-from textual.message import Message, MessageTarget
+from textual.message import Message
 from textual.reactive import reactive
 
 
@@ -217,11 +217,11 @@ class IpTablesBoard(Static):
         )
 
     class SelectTableChain(Message):
-        def __init__(self, sender: MessageTarget, table: str, chain: str):
+        def __init__(self, table: str, chain: str):
             self.table = table
             self.chain = chain
-            super().__init__(sender)
+            super().__init__()
 
     async def on_button_pressed(self, event: Button.Pressed):
         table, chain = event.button.id.split("-")
-        await self.post_message(self.SelectTableChain(self, table, chain))
+        self.post_message(self.SelectTableChain(table, chain))


### PR DESCRIPTION
With textual v0.14, MessageTarget use has changed.It's not needed anymore to import "MessageTarget".

ref: https://textual.textualize.io/blog/2023/03/09/textual-0140-shakes-up-posting-messages/